### PR TITLE
Build without warnings using GHC 9.0

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.12.1
+# version: 0.14
 #
-# REGENDATA ("0.12.1",["github","golang.cabal"])
+# REGENDATA ("0.14",["github","golang.cabal"])
 #
 name: Haskell-CI
 on:
@@ -20,51 +20,91 @@ jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
+    timeout-minutes:
+      60
     container:
-      image: buildpack-deps:xenial
+      image: buildpack-deps:bionic
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.0.2
+            compilerKind: ghc
+            compilerVersion: 9.0.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-8.10.4
+            compilerKind: ghc
+            compilerVersion: 8.10.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.8.4
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.6.5
+            compilerKind: ghc
+            compilerVersion: 8.6.5
+            setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y $CC cabal-install-3.4
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "$HCNAME"
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          fi
         env:
-          CC: ${{ matrix.compiler }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "LANG=C.UTF-8" >> $GITHUB_ENV
-          echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
-          echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HCDIR=$(echo "/opt/$CC" | sed 's/-/\//')
-          HCNAME=ghc
-          HC=$HCDIR/bin/$HCNAME
-          echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=$HCDIR/bin/$HCNAME-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=$HCDIR/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
+          echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+          echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
+          HCDIR=/opt/$HCKIND/$HCVER
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
-          echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
-          echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
-          echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
-          echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--$HCNAME --with-compiler=$HC" >> $GITHUB_ENV
-          echo "GHCJSARITH=0" >> $GITHUB_ENV
+          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
+          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
-          CC: ${{ matrix.compiler }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: env
         run: |
           env
@@ -86,6 +126,10 @@ jobs:
             prefix: $CABAL_DIR
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
+          EOF
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
           EOF
           cat $CABAL_CONFIG
       - name: versions
@@ -125,7 +169,8 @@ jobs:
       - name: generate cabal.project
         run: |
           PKGDIR_golang="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/golang-[0-9.]*')"
-          echo "PKGDIR_golang=${PKGDIR_golang}" >> $GITHUB_ENV
+          echo "PKGDIR_golang=${PKGDIR_golang}" >> "$GITHUB_ENV"
+          rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_golang}" >> cabal.project

--- a/golang.cabal
+++ b/golang.cabal
@@ -4,12 +4,12 @@ synopsis:            A parser frontend for Go designed to be used with goblin.
 description:
   This is a parser frontend for the Go programming language designed to be used
   with goblin.
-  
+
   The abstract syntax and type definitions are in AST.hs and Types.hs,
   respectively. Rec.hs contains generic combinators for folding over the syntax.
-  
+
   The frontend proceeds in three phases:
-  
+
   * The JSON parser (Parser.hs) deserializes a JSON-encoded AST produced by
     goblin.
   * The desugaring pass (Desugar.hs) performs various (purely syntactic)
@@ -36,7 +36,7 @@ Source-repository this
    type: git
    location: git://github.com/GaloisInc/golang
    tag: 0.1.0.0
-                     
+
 library
   exposed-modules:     Language.Go.AST
                        Language.Go.Desugar
@@ -44,8 +44,8 @@ library
                        Language.Go.Rec
                        Language.Go.Rename
                        Language.Go.Types
-  other-modules:       
-  build-depends:       base == 4.*
+  other-modules:
+  build-depends:       base >= 4.9 && < 5
                      , mtl
                      , text >= 1.2
                      , aeson
@@ -57,4 +57,4 @@ library
   hs-source-dirs:      src
   ghc-options:       -Wall -fno-warn-orphans -Wno-unticked-promoted-constructors
   default-language:    Haskell2010
-  Build-tools:         
+  Build-tools:

--- a/golang.cabal
+++ b/golang.cabal
@@ -21,7 +21,7 @@ license-file:        LICENSE
 author:              Alex Bagnall
 maintainer:          Alex Bagnall <abagnall@galois.com>, Tristan Ravitch <tristan@galois.com>
 copyright:           (c) 2020-2021 Galois Inc.
-tested-with:         GHC==8.6.5, GHC==8.8.4, GHC==8.10.4
+tested-with:         GHC==8.6.5, GHC==8.8.4, GHC==8.10.4, GHC==9.0.2
 homepage:            https://github.com/GaloisInc/golang
 bug-reports:         https://github.com/GaloisInc/golang/issues
 category:            Language

--- a/src/Language/Go/AST.hs
+++ b/src/Language/Go/AST.hs
@@ -752,7 +752,7 @@ stringConst x str = In $ BasicConstExpr x stringType $ BasicConstString str
 
 -- | Zero value expressions for every type.
 zeroExpr :: a -> Type -> Node a Expr
-zeroExpr x NoType = error "zeroExpr: NoType"
+zeroExpr _ NoType = error "zeroExpr: NoType"
 zeroExpr x (ArrayType len tp) = zeroArray x len tp
 zeroExpr x (BasicType basicKind) = zeroBasic x basicKind
 zeroExpr x tp@(ChanType _dir _tp) = In $ NilExpr x tp
@@ -762,11 +762,11 @@ zeroExpr x (NamedType tp) = zeroExpr x tp
 zeroExpr x tp@(PointerType _tp) = In $ NilExpr x tp
 zeroExpr x tp@(FuncType _recv _params _return _variadic) = In $ NilExpr x tp
 zeroExpr x tp@(SliceType _tp) = In $ NilExpr x tp
-zeroExpr x (StructType fields) = error "zeroExpr: struct not yet supported"
+zeroExpr _ (StructType _fields) = error "zeroExpr: struct not yet supported"
 zeroExpr x (TupleType fields) = zeroTuple x fields
 
 zeroBasic :: a -> BasicKind -> Node a Expr
-zeroBasic x BasicInvalid = error ""
+zeroBasic _ BasicInvalid = error ""
 zeroBasic x BasicBool = boolConst x False
 zeroBasic x (BasicInt w) = intConst x w 0
 zeroBasic x (BasicUInt w) = uintConst x w 0

--- a/src/Language/Go/AST.hs
+++ b/src/Language/Go/AST.hs
@@ -28,6 +28,7 @@ constant expressions (most literals end up as BasicConstExprs).
 {-# LANGUAGE StandaloneDeriving #-}
 module Language.Go.AST where
 
+import qualified Data.Kind as Kind
 import           Data.Text hiding (inits, replicate)
 
 import           Data.Parameterized.TraversableFC
@@ -42,7 +43,7 @@ import           Language.Go.Types
 type Node a = Fix (NodeF a)
 
 -- | Go AST node functor indexed by NodeType.
-data NodeF (a :: *) (f :: NodeType -> *) (i :: NodeType) where
+data NodeF (a :: Kind.Type) (f :: NodeType -> Kind.Type) (i :: NodeType) where
 
   -- | The main package.
   MainNode :: Text -- ^ main package name
@@ -194,7 +195,7 @@ data NodeF (a :: *) (f :: NodeType -> *) (i :: NodeType) where
   ----------------------------------------------------------------------
   -- Expressions
 
-  -- | A literal of basic type. 
+  -- | A literal of basic type.
   BasicLitExpr :: a -> Type -> BasicLit -> NodeF a f Expr
 
   -- | A constant value produced by the Go typechecker's constant
@@ -454,7 +455,7 @@ data BasicLitType =
   | LiteralString
   deriving (Eq, Show)
 
--- | A literal of basic type. 
+-- | A literal of basic type.
 data BasicLit =
   BasicLit
   { basiclit_type :: BasicLitType -- ^ "kind" of the literal
@@ -748,7 +749,7 @@ complexConst x w real imag =
 
 stringConst :: a -> Text -> Node a Expr
 stringConst x str = In $ BasicConstExpr x stringType $ BasicConstString str
-  
+
 -- | Zero value expressions for every type.
 zeroExpr :: a -> Type -> Node a Expr
 zeroExpr x NoType = error "zeroExpr: NoType"


### PR DESCRIPTION
As of GHC 9.0.1, `-Wall` enables `-Wstar-is-type`, which warns if `*` is used as a kind instead of `Type` (from `Data.Kind`). This patch fixes two `-Wstar-is-type` warnings in `Language.Go.AST`.

Since `Data.Kind` has only been around since GHC 8.0, I bumped the lower version bounds on `base` to `>= 4.9` to ensure that `Data.Kind` is always available.

While I was in town, I also fixed some lingering `-Wunused-matches` warnings and added GHC 9.0.2 to CI.