### PR TITLE
Support building with GHC 9.2

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14
+# version: 0.14.3
 #
-# REGENDATA ("0.14",["github","golang.cabal"])
+# REGENDATA ("0.14.3",["github","golang.cabal"])
 #
 name: Haskell-CI
 on:
@@ -28,15 +28,20 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.2.2
+            compilerKind: ghc
+            compilerVersion: 9.2.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.0.2
             compilerKind: ghc
             compilerVersion: 9.0.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.4
+          - compiler: ghc-8.10.7
             compilerKind: ghc
-            compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            compilerVersion: 8.10.7
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
@@ -56,7 +61,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
@@ -65,7 +70,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work
 dist/
 dist-newstyle/
+/cabal.project

--- a/cabal.project.dist
+++ b/cabal.project.dist
@@ -1,0 +1,1 @@
+packages: .

--- a/golang.cabal
+++ b/golang.cabal
@@ -21,7 +21,7 @@ license-file:        LICENSE
 author:              Alex Bagnall
 maintainer:          Alex Bagnall <abagnall@galois.com>, Tristan Ravitch <tristan@galois.com>
 copyright:           (c) 2020-2021 Galois Inc.
-tested-with:         GHC==8.6.5, GHC==8.8.4, GHC==8.10.4, GHC==9.0.2
+tested-with:         GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.2
 homepage:            https://github.com/GaloisInc/golang
 bug-reports:         https://github.com/GaloisInc/golang/issues
 category:            Language

--- a/src/Language/Go/Parser.hs
+++ b/src/Language/Go/Parser.hs
@@ -7,6 +7,7 @@ Stability   : experimental
 Parse JSON-encoded Go ASTs.
 -}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE OverloadedStrings #-}


### PR DESCRIPTION
In GHC 9.2, enabling `UndecidableInstances` no longer implies enabling `FlexibleContexts` (see [here](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2?version_id=7e2ce63ba042c1934654c4316dc02028d8d3dd31#undecidableinstances-no-longer-implies-flexiblecontexts-in-instance-declarations)). As a result, I had to enable `FlexibleContexts` in `Language.Go.Parser`.